### PR TITLE
Use regexp rather than a shell pattern for the history file.

### DIFF
--- a/index.pl
+++ b/index.pl
@@ -107,8 +107,8 @@ foreach my $configfile (@files) {
                         map { $_->[0] }
                         sort { $a->[1] <=> $b->[1] }
                         map { [$_, ((stat catfile($cachedir, $_))[9])]; }
-                        File::Find::Rule->file
-                            ->name("awstats[0-9]*.$configname.txt")
+                           File::Find::Rule->file
+                            ->name(qr/awstats[0-9]{6}.$configname.txt$/)
                             ->relative
                             ->in($cachedir)
                         )[-1]) {


### PR DESCRIPTION
Rationale: I have configured my AWStats to compute statistics for
several sub-domains as well as over-all statistics for the entire thing,
so there are configs for, e.g.,

john.doe.com
jane.doe.com
doe.com

The previously used shell patterns selected the wrong history file in
this case.